### PR TITLE
added a feature to create portable builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ winres = "0.1"
 [features]
 embedded-server = [ "tauri/embedded-server" ]
 no-server = [ "tauri/no-server" ]
+portable = [ ]
 
 [[bin]]
 name = "cabr2"

--- a/src-tauri/src/config/handler.rs
+++ b/src-tauri/src/config/handler.rs
@@ -17,7 +17,7 @@ pub fn get_config() -> Result<JsonConfig> {
 
 pub fn read_config() -> Result<TomlConfig> {
   let config_path = get_config_path();
-  log::error!("reading config from: {:?}", config_path);
+  log::trace!("reading config from: {:?}", config_path);
 
   let mut file = match OpenOptions::new().read(true).open(config_path) {
     Ok(file) => file,

--- a/src-tauri/src/config/handler.rs
+++ b/src-tauri/src/config/handler.rs
@@ -17,7 +17,7 @@ pub fn get_config() -> Result<JsonConfig> {
 
 pub fn read_config() -> Result<TomlConfig> {
   let config_path = get_config_path();
-  log::trace!("reading config from: {:?}", config_path);
+  log::error!("reading config from: {:?}", config_path);
 
   let mut file = match OpenOptions::new().read(true).open(config_path) {
     Ok(file) => file,
@@ -90,16 +90,26 @@ pub fn get_hazard_symbols() -> Result<GHSSymbols> {
 #[cfg(not(debug_assertions))]
 #[inline]
 fn get_config_path() -> PathBuf {
-  use super::PROJECT_DIRS;
-  let mut conf_dir = PROJECT_DIRS.config_dir().to_path_buf();
+  #[cfg(not(feature = "portable"))]
+  {
+    use super::PROJECT_DIRS;
+    let mut conf_dir = PROJECT_DIRS.config_dir().to_path_buf();
 
-  if !conf_dir.exists() {
-    std::fs::create_dir_all(&conf_dir).unwrap();
+    if !conf_dir.exists() {
+      std::fs::create_dir_all(&conf_dir).unwrap();
+    }
+
+    conf_dir.push("config.toml");
+
+    conf_dir
   }
 
-  conf_dir.push("config.toml");
-
-  conf_dir
+  #[cfg(feature = "portable")]
+  {
+    let mut cfg_path = PathBuf::from(std::env::args().next().unwrap());
+    cfg_path.push("config.toml");
+    cfg_path
+  }
 }
 
 #[cfg(debug_assertions)]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -76,13 +76,22 @@ impl Plugin for Config {
 fn get_program_data_dir() -> PathBuf {
   #[cfg(not(debug_assertions))]
   {
-    #[cfg(target_os = "linux")]
-    return PathBuf::from("/usr/lib/cabr2/");
+    #[cfg(not(feature = "portable"))]
+    {
+      #[cfg(target_os = "linux")]
+      return PathBuf::from("/usr/lib/cabr2/");
 
-    #[cfg(target_os = "macos")]
-    unimplemented!();
+      #[cfg(target_os = "macos")]
+      unimplemented!();
 
-    #[cfg(target_os = "windows")]
+      #[cfg(target_os = "windows")]
+      return PathBuf::from(env::args().next().unwrap())
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    }
+
+    #[cfg(feature = "portable")]
     return PathBuf::from(env::args().next().unwrap())
       .parent()
       .unwrap()
@@ -90,8 +99,13 @@ fn get_program_data_dir() -> PathBuf {
   }
 
   #[cfg(debug_assertions)]
-  let mut program_path = PathBuf::from(env::args().next().unwrap()).parent().unwrap().to_path_buf();
-  // git repo root
-  program_path.push("../../../");
-  program_path.canonicalize().unwrap()
+  {
+    let mut program_path = PathBuf::from(env::args().next().unwrap())
+      .parent()
+      .unwrap()
+      .to_path_buf();
+    // git repo root
+    program_path.push("../../../");
+    program_path.canonicalize().unwrap()
+  }
 }


### PR DESCRIPTION
all paths (except `tmp` path) point to the path in which the binary is located.